### PR TITLE
Add description and fix type errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ wrangler.toml
 .vscode/*
 !.vscode/launch.json
 !.vscode/*.code-snippets
+*/rss.xml
 
 # deps
 node_modules/

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,7 +1,6 @@
-import {} from "hono";
-
-type Head = {
+export type Head = {
   title?: string;
+  description?: string;
   category?: string;
   publishedAt?: string;
   ogpImage?: string;
@@ -11,7 +10,9 @@ declare module "hono" {
   interface ContextRenderer {
     (
       content: string | Promise<string>,
-      head?: Head & { frontmatter?: Head; description?: string; ogpImage?: string },
+      head?: Head & {
+        frontmatter?: Head;
+      },
     ): Response | Promise<Response>;
   }
 }

--- a/app/routes/posts.tsx
+++ b/app/routes/posts.tsx
@@ -1,15 +1,9 @@
 import { createRoute } from "honox/factory";
 import { PostsPresenter } from "../components/posts/PostsPresenter";
-
-export type Meta = {
-  title: string;
-  category: string;
-  publishedAt: string;
-  ogpImage?: string;
-};
+import type { Head } from "../global";
 
 export default createRoute(async (c) => {
-  const rawPosts = import.meta.glob<{ frontmatter: Meta }>("./posts/*.mdx", {
+  const rawPosts = import.meta.glob<{ frontmatter: Head }>("./posts/*.mdx", {
     eager: true,
   });
 
@@ -21,7 +15,6 @@ export default createRoute(async (c) => {
       title: module.frontmatter.title ?? "",
       category: module.frontmatter.category ?? "",
       publishedAt: new Date(module.frontmatter.publishedAt) ?? "",
-      ogpImage: module.frontmatter.ogpImage,
     }))
     .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
 

--- a/app/routes/posts/_renderer.tsx
+++ b/app/routes/posts/_renderer.tsx
@@ -2,9 +2,14 @@ import { jsxRenderer } from "hono/jsx-renderer";
 import { PostDetailHeader } from "../../components/posts/detail/PostDetailHeader";
 
 export default jsxRenderer(({ children, Layout, frontmatter }) => {
+  const _title = frontmatter?.title ?? "";
+  const _description = frontmatter?.description;
+  const _publishedAt = frontmatter?.publishedAt ?? "";
+  const _ogpImage = frontmatter?.ogpImage;
+
   return (
-    <Layout title={frontmatter?.title} ogpImage={frontmatter?.ogpImage}>
-      <PostDetailHeader title={frontmatter?.title ?? ""} publishedAt={frontmatter?.publishedAt ?? ""} />
+    <Layout title={_title} description={_description} ogpImage={_ogpImage}>
+      <PostDetailHeader title={_title} publishedAt={_publishedAt} />
       <article class="markdown-body">{children}</article>
     </Layout>
   );

--- a/app/routes/posts/js-engine-and-test262.mdx
+++ b/app/routes/posts/js-engine-and-test262.mdx
@@ -1,5 +1,6 @@
 ---
 title: JS Engine と Test262 について調べる
+description: JS Engine と Test262 について調べたことを残します
 category: tech
 publishedAt: 2025/02/24
 ---

--- a/app/routes/posts/md-test.mdx
+++ b/app/routes/posts/md-test.mdx
@@ -1,5 +1,6 @@
 ---
-title: Markdown試し打ち
+title: Markdown 試し打ち
+description: Markdown の試し打ちです
 category: tech
 publishedAt: 2024/09/14
 ---

--- a/app/routes/posts/review-2024.mdx
+++ b/app/routes/posts/review-2024.mdx
@@ -1,5 +1,6 @@
 ---
 title: 2024年振り返り
+description: taga3s の 2024 年を振り返ります
 category: weekly
 publishedAt: 2024/12/31
 ogpImage: ogp-review-2024.png

--- a/app/routes/posts/weekly2025-02-23.mdx
+++ b/app/routes/posts/weekly2025-02-23.mdx
@@ -1,5 +1,6 @@
 ---
 title: This week in taga3s / 2025-02-23
+description: taga3s が今週気になったことを紹介します
 category: weekly
 publishedAt: 2025/02/23
 ---

--- a/app/routes/posts/weekly2025-03-02.mdx
+++ b/app/routes/posts/weekly2025-03-02.mdx
@@ -1,5 +1,6 @@
 ---
 title: This week in taga3s / 2025-03-02
+description: taga3s が今週気になったことを紹介します
 category: weekly
 publishedAt: 2025/03/02
 ---

--- a/scripts/generate-rss.ts
+++ b/scripts/generate-rss.ts
@@ -11,13 +11,14 @@ import { unified } from "unified";
 
 type Frontmatter = {
   title: string;
+  description: string;
   category: string;
   publishedAt: string;
   ogpImage?: string;
 };
 
 const validateFrontmatter = (value: any): value is Frontmatter => {
-  return "title" in value && "category" in value && "publishedAt" in value;
+  return "title" in value && "description" in value && "category" in value && "publishedAt" in value;
 };
 
 const channel: Channel = {
@@ -53,6 +54,7 @@ for (const filename of postFilenames) {
 
   items.push({
     title: frontmatter.title,
+    description: cdata(frontmatter.description),
     category: [frontmatter.category],
     link: link,
     guid: {


### PR DESCRIPTION
## description
This pull request includes several changes to improve the handling of post metadata and ensure consistency across the application. The most important changes include updating the metadata type, adding descriptions to posts, and modifying the RSS generation script to include descriptions.

Metadata type update:

* [`app/routes/posts.tsx`](diffhunk://#diff-cc3883c9fee04de80730f3af35658b2570dd4c01fc9715fab4f02add4fce4aacL3-R6): Changed the type of `frontmatter` from `Meta` to `Head` to align with the global metadata type.
* [`app/routes/posts.tsx`](diffhunk://#diff-cc3883c9fee04de80730f3af35658b2570dd4c01fc9715fab4f02add4fce4aacL24): Removed the `ogpImage` property from the `frontmatter` object in the sorting function.

Adding descriptions to posts:

* [`app/routes/posts/js-engine-and-test262.mdx`](diffhunk://#diff-f2cfb2a9aa2a6ac1b45bba55641a57216b05d19a7edfd0f15606b79c283353ffR3): Added a `description` field to the frontmatter.
* [`app/routes/posts/md-test.mdx`](diffhunk://#diff-9f330a8ba85b0c2d4fd2d9a46582c3519d3f820bea8759c76a8f9bd18292c329R3): Added a `description` field to the frontmatter.
* [`app/routes/posts/review-2024.mdx`](diffhunk://#diff-e1bf1779dbc252ba1f5078731bbc2bd8c72e9cebe751303420f26dcd0a4f1af1R3): Added a `description` field to the frontmatter.
* [`app/routes/posts/weekly2025-02-23.mdx`](diffhunk://#diff-3653b2adcebdfb046e3d404a521a6058e997cfa2ab48b6b296a3ab9c9f630834R3): Added a `description` field to the frontmatter.
* [`app/routes/posts/weekly2025-03-02.mdx`](diffhunk://#diff-2b5ca9f895336688596a877937cdc6955a887635a6251d4b1d2fcadf666014edR3): Added a `description` field to the frontmatter.

RSS generation script update:

* [`scripts/generate-rss.ts`](diffhunk://#diff-45df96baf3061d462afbde131eeead0cf0a8ddff81123ca8e7d4d231723b146fR14-R21): Updated the `Frontmatter` type to include a `description` field and modified the `validateFrontmatter` function to check for the `description` field.
* [`scripts/generate-rss.ts`](diffhunk://#diff-45df96baf3061d462afbde131eeead0cf0a8ddff81123ca8e7d4d231723b146fR57): Added the `description` field to the RSS items.

Additionally, the renderer component for posts was updated to use local variables for metadata properties to improve readability:

* [`app/routes/posts/_renderer.tsx`](diffhunk://#diff-6e4f3ca4bf18f8ff9aa7918539a8f40be98101eb5430efbef2603ac6c097e9e0R5-R12): Introduced local variables for `title`, `description`, `publishedAt`, and `ogpImage` to improve the readability of the JSX layout.